### PR TITLE
Enables programmatic setting of the input display value upon initialization

### DIFF
--- a/dist/components/calendar.js
+++ b/dist/components/calendar.js
@@ -156,7 +156,7 @@
             },
             date: function () {
               if ($input.length) {
-                var val = $input.val();
+                var val = settings.displayValue ? settings.displayValue :$input.val();
                 var date = parser.date(val, settings);
                 module.set.date(date, settings.formatInput, false);
               }
@@ -918,6 +918,7 @@
     inline: false,        // create the calendar inline instead of inside a popup
     on: null,             // when to show the popup (defaults to 'focus' for input, 'click' for others)
     initialDate: null,    // date to display initially when no date is selected (null = now)
+    displayValue: null,   // date to display in input (formatted with formatter)
     startMode: false,     // display mode to start in, can be 'year', 'month', 'day', 'hour', 'minute' (false = 'day')
     minDate: null,        // minimum date/time that can be selected, dates/times before are disabled
     maxDate: null,        // maximum date/time that can be selected, dates/times after are disabled


### PR DESCRIPTION
Adds a settings property that can be used to programmatically set the view value upon initialization. The `initialDate` property did not set the inputs view value, so I added this.

I was running into issues where I was unable to set the inputs view value programmatically during initialization.  In cases where the inputs `view` property could not be set before initialization I needed a way to set it programmatically. This adds a settings property, and a ternary check to set that value.
